### PR TITLE
Fix Addon name to match NodeIMU

### DIFF
--- a/addon.cpp
+++ b/addon.cpp
@@ -6,4 +6,4 @@ NAN_MODULE_INIT(Init) {
   NodeIMU::Init(target);
 }
 
-NODE_MODULE(addon, Init)
+NODE_MODULE(NodeIMU, Init)


### PR DESCRIPTION
When running on node 0.10 (still the default version of node on the RaspberryPi...) requiring this module hits an error:

```
Error: Symbol NodeIMU_module not found.
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pi/code/node-hat/node_modules/nodeimu/index.js:1:90)
```

After some investigation, I spotted the Addon name passed to the call to `NODE_MODULE` didn't match what was declared in `binding.gyp`.

I have verified the change in this PR enables the module to be required and used successfully on node 0.10 and 4.3.1.

I don't know enough about the workings of `nan`/`node-gyp` to say why it already worked on node 0.12 and later.
