### PR TITLE
Update node-gyp dependency version from 6.1.0 to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "types": "./index.d.ts",
   "dependencies": {
     "nan": "^2.14.0",
-    "node-gyp": "^6.1.0"
+    "node-gyp": "latest"
   },
   "keywords": [
     "raspberry",


### PR DESCRIPTION
Installation of nodeimu module with Python > 3.10 fails with error:

npm ERR!   File "/usr/local/lib/node_modules/node-sense-hat/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 234, in LoadOneBuildFile
npm ERR!     build_file_contents = open(build_file_path, 'rU').read()
npm ERR!                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
npm ERR! ValueError: invalid mode: 'rU' while trying to load binding.gyp

Found with latest Raspios distribution trying to install node-sense-hat module.

This error is documented [here](https://stackoverflow.com/questions/74715990/node-gyp-err-invalid-mode-ru-while-trying-to-load-binding-gyp) and happens in current Linux distributions as they no longer use Python 3.10.

Migration of node-gyp dependency from version 6.1.0 to latest version enables compatibility with Python > 3.10.